### PR TITLE
Fix load path

### DIFF
--- a/bin/conveyor
+++ b/bin/conveyor
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+$LOAD_PATH.unshift(File.expand_path(File.join(File.dirname(__FILE__), "..", "lib")))
+
 require 'rubygems'
 require 'conveyor'
 


### PR DESCRIPTION
@teknofire   This fixes the load path so that conveyor can be run when not installed as a gem
