### PR TITLE
Modify logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ log/*
 pkg
 .conveyor
 data_test
+tmp

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    gina-conveyor (1.0.1)
+    gina-conveyor (1.0.3)
       activemodel (~> 4.1.0)
       activesupport (~> 4.1.0)
       em-websocket (~> 0.5.1)
@@ -14,10 +14,10 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    activemodel (4.1.13)
-      activesupport (= 4.1.13)
+    activemodel (4.1.16)
+      activesupport (= 4.1.16)
       builder (~> 3.1)
-    activesupport (4.1.13)
+    activesupport (4.1.16)
       i18n (~> 0.6, >= 0.6.9)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -29,8 +29,8 @@ GEM
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
-    eventmachine (1.0.8)
-    ffi (1.9.10)
+    eventmachine (1.0.9.1)
+    ffi (1.9.14)
     hitimes (1.2.3)
     http_parser.rb (0.6.0)
     i18n (0.7.0)
@@ -39,12 +39,12 @@ GEM
       celluloid (~> 0.16.0)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
-    minitest (5.8.1)
-    mixlib-shellout (2.2.1)
+    minitest (5.9.0)
+    mixlib-shellout (2.2.7)
     rainbow (2.0.0)
     rake (10.3.2)
-    rb-fsevent (0.9.6)
-    rb-inotify (0.9.5)
+    rb-fsevent (0.9.7)
+    rb-inotify (0.9.7)
       ffi (>= 0.5.0)
     rb-readline (0.5.3)
     thread_safe (0.3.5)
@@ -61,4 +61,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.10.6
+   1.12.5

--- a/lib/conveyor.rb
+++ b/lib/conveyor.rb
@@ -53,9 +53,9 @@ module Conveyor
       fm.info "Press CTRL-C to stop"
       Conveyor::Websocket.start
 
-      EventMachine::PeriodicTimer.new(1) do
-        fm.output_status
-      end
+      # EventMachine::PeriodicTimer.new(30) do
+      #   fm.output_status
+      # end
 
       EventMachine::PeriodicTimer.new(1) do
         fm.check

--- a/lib/conveyor/belt.rb
+++ b/lib/conveyor/belt.rb
@@ -1,12 +1,12 @@
 module Conveyor
-  # Does not persist, do not use any class variables 
+  # Does not persist, do not use any class variables
   class Belt
     SETTLE_TIME = 30
 
     include Conveyor::Output
 
     attr_reader :command_file
-    
+
     def initialize(watch_path, command_file)#, opts = {})
       @work_dir = watch_path
       @command_file = command_file
@@ -26,11 +26,13 @@ module Conveyor
         @queue.push(f)
       end
     end
-    
+
     def check
+      info "#{name}: #{count} jobs pending" if count > 0
       job = @queue.reserve
+      return if job.nil?
       # puts job.inspect
-      if job && (Time.now - job[:updated_at]) > SETTLE_TIME
+      if (Time.now - job[:updated_at]) > SETTLE_TIME
         Worker.new(job[:file], @command_file).start
         # Worker done remove it from the queue
         @queue.pop(job[:file])
@@ -49,11 +51,11 @@ module Conveyor
     end
 
     def escape_glob(glob)
-      if glob.class == String 
+      if glob.class == String
         Regexp.new(glob)
-      else 
+      else
         glob
       end
-    end  
+    end
   end
 end

--- a/lib/conveyor/foreman.rb
+++ b/lib/conveyor/foreman.rb
@@ -113,6 +113,7 @@ module Conveyor
 
     def any
       '*'
+      /.*/
     end
 
     def notify_list
@@ -137,7 +138,7 @@ module Conveyor
 
     def output_status
       status = @belts.collect { |dir, b| "#{b.name}: #{b.count}" }
-      print "\r#{status.join(', ')}"
+      info status.join(', ')
     end
 
     def check

--- a/lib/conveyor/output.rb
+++ b/lib/conveyor/output.rb
@@ -65,9 +65,6 @@ module Conveyor
     def output(msgtype, *msg)
       return false unless should_log?(msgtype)
       Console.write(msgtype, *msg)
-      Logfile.write(logfile, name, msgtype, *msg)
-      Email.write(msgtype, *msg)
-      Channel.instance.write(name, msgtype, *msg)
     end
 
     def send_notifications

--- a/lib/conveyor/output/console.rb
+++ b/lib/conveyor/output/console.rb
@@ -7,32 +7,29 @@ module Conveyor
             self.send(msgtype, *msg)
           end
         end
-        
+
         def output(*msg)
           options = msg.extract_options!
           options[:color] ||= :default
           options[:tab] ||= 0
 
-          format = "\t"*options[:tab]
-          format << "\r[%s] %s"
-          if msg.class == Array
-            msg.each do |m|
-              puts sprintf(format, Time.now, m).color(options[:color])              
-            end
-          else
-            puts sprintf(format, Time.now, msg).color(options[:color])              
+          tabs = "\t" * options[:tab]
+          format = "#{tabs}[%s] %s"
+
+          Array(msg).each do |m|
+            puts sprintf(format, Time.now, m).color(options[:color])
           end
         end
         alias_method :info, :output
         alias_method :debug, :output
-        
+
         def warning(*msg)
           options = msg.extract_options!
           options[:color] ||= :yellow
           msg.flatten!
           output(*msg, options)
         end
-                
+
         def error(*msg)
           options = msg.extract_options!
           options[:color] ||= :red


### PR DESCRIPTION
@teknofire  This modifies conveyor to not use print and \r for logging, and disabled all but the STDOUT logger.   It also modifies the notification of pending work to compensate for the loss of the status line. 
